### PR TITLE
Fix/remove hardcoded authors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,8 +10,8 @@ omit =
     */__init__.py
     backend\manage.py 
     backend\config\*
-    backend\backend\models\*
-    backend\backend\admin\*
+    backend\models\*
+    backend\admin\*
 include_namespace_packages = true
 show_missing = True
 skip_empty = true

--- a/backend/DOCKERFILE
+++ b/backend/DOCKERFILE
@@ -5,6 +5,9 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# To run pytest
+COPY .coveragerc .coveragerc
+
 COPY backend/ .
 
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/backend/test/test_get_publications.py
+++ b/backend/backend/test/test_get_publications.py
@@ -24,6 +24,20 @@ def test_clean_title(input_title, expected_output):
     assert command._clean_title(input_title) == expected_output
 
 
+@pytest.mark.django_db
+@patch("backend.management.commands.getpublications.Member")
+def test_get_lab_members(mock_member):
+    mock_member1 = MagicMock(first_name="John", last_name="Doe")
+    mock_member2 = MagicMock(first_name="Jane", last_name="Smith")
+
+    mock_member.objects.all.return_value = [mock_member1, mock_member2]
+
+    obj = Command()
+    result = obj._get_lab_members()
+
+    assert result == ["John Doe", "Jane Smith"]
+
+
 @pytest.fixture(autouse=True)
 def disable_django_logging():
     logging.disable(logging.CRITICAL)


### PR DESCRIPTION
## Description
This PR adds a method to use all members from the database instead of using a hardcoded set of values. The hardcoded values will be used as a fall back mechanism if for some reason the Members table is empty

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (Please describe):

## Screenshots
Please provide screenshots of the changes, if possible.

## Additional Notes
Any additional notes or context regarding the changes can be added here.
