### PR TITLE
Moved API URL host to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DB_PASSWORD=CHANGE_ME
 DB_HOST=db
 DB_PORT=5432
 DB_NAME=postgres
+
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
 3. Use the command:

--- a/doc/global/database.puml
+++ b/doc/global/database.puml
@@ -35,10 +35,13 @@ entity User {
 
 entity ResearchProject {
   primary_key(id): UUID
+  foreign_key(leader_id): UUID
   title: VARCHAR
   start_date: DATE
   end_date: DATE
   description: TEXT
+  github_url: TEXT
+  project_url: TEXT
 }
 
 entity ProjectParticipant {
@@ -112,4 +115,6 @@ Award ||--o{ AwardRecipient : has >
 Member ||--o{ AwardRecipient : receives >
 Publication ||--o{ PublicationAuthor : includes >
 Author ||--o{ PublicationAuthor : writes >
+Member ||--o{ ResearchProject : leads >
+
 @enduml

--- a/doc/programmerGuide/programmerGuide.md
+++ b/doc/programmerGuide/programmerGuide.md
@@ -101,6 +101,8 @@ DB_PASSWORD=CHANGE_ME
 DB_HOST=db
 DB_PORT=5432
 DB_NAME=postgres
+
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
 4. Use the command:

--- a/src/components/auth/RegisterForm.vue
+++ b/src/components/auth/RegisterForm.vue
@@ -94,8 +94,9 @@ const handleSubmit = async () => {
   generalError.value = ''
   errors.value = {}
 
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
   try {
-    const response = await fetch('http://localhost:8000/api/register', {
+    const response = await fetch(`${API_BASE_URL}/api/register`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/components/awards/AwardsPage.vue
+++ b/src/components/awards/AwardsPage.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useLanguage } from '@/composables/useLanguage'
-import { mockResearchers } from '@/data/mockResearchers'
 
 // UI Components
 import PageHeader from '@/ui/PageHeader.vue'
@@ -51,10 +50,11 @@ const selectedOrganization = ref('')
 const selectedMember = ref('')
 const currentYear = new Date().getFullYear()
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 // Generate all awards from researchers
 const fetchAwards = async () => {
   try {
-    const response = await fetch('http://localhost:8000/api/awards')
+    const response = await fetch(`${API_BASE_URL}/api/awards`)
     if (!response.ok) throw new Error('Failed to fetch awards')
     const data = await response.json()
     allAwards.value = Array.isArray(data) ? data : []

--- a/src/components/forms/PublicationForm.vue
+++ b/src/components/forms/PublicationForm.vue
@@ -203,7 +203,8 @@ const handleSubmit = async () => {
       id: form.citekey.toLowerCase(),
     }
 
-    const response = await axios.post('http://localhost:8000/api/publications/', payload)
+    const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+    const response = await axios.post(`${API_BASE_URL}/api/publications/`, payload)
 
     alert('Publication created successfully!')
     clearForm()

--- a/src/components/people/PeoplePage.vue
+++ b/src/components/people/PeoplePage.vue
@@ -31,10 +31,11 @@ const selectedMember = ref<Member | null>(null)
 // Language
 const { t } = useLanguage()
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 // Fetch members on mount
 const fetchMembers = async () => {
   try {
-    const response = await fetch('http://localhost:8000/api/members')
+    const response = await fetch(`${API_BASE_URL}/api/members`)
     if (!response.ok) throw new Error('Failed to fetch members')
     const data = await response.json()
     members.value = Array.isArray(data) ? data : []

--- a/src/components/publications/PublicationsPage.vue
+++ b/src/components/publications/PublicationsPage.vue
@@ -21,10 +21,11 @@ const selectedYear = ref('')
 const selectedType = ref('')
 const sortBy = ref('year-desc')
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 // Fetch publications on mount
 onMounted(async () => {
   try {
-    const response = await axios.get('http://localhost:8000/api/publications/')
+    const response = await axios.get(`${API_BASE_URL}/api/publications/`)
     publications.value = response.data
   } catch (error) {
     console.error('Failed to fetch publications:', error)


### PR DESCRIPTION
## Description
Moved API URL host to .env + updated database schema

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (Please describe):

## Screenshots
**⚠️IMPORTANT⚠️**: Please add this line to your env file : 
```bash
VITE_API_BASE_URL=http://localhost:8000
```

API calls in the frontend should now use this variable. Example : 
<img width="712" height="477" alt="image" src="https://github.com/user-attachments/assets/66825d8a-ce5a-4ddf-9c55-f8c6e20b937d" />


## Additional Notes
Any additional notes or context regarding the changes can be added here.
