### PR TITLE
[FEAT]: Display researches on UI

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "backend",
     "rest_framework",
+    "drf_yasg",
 ]
 
 REST_FRAMEWORK = {"DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework_simplejwt.authentication.JWTAuthentication",)}

--- a/src/components/research/FeaturedProjects.vue
+++ b/src/components/research/FeaturedProjects.vue
@@ -1,7 +1,26 @@
 <script setup lang="ts">
 import { useLanguage } from '@/composables/useLanguage'
-import type { Project } from '@/data/mockPublications'
 import Card from '@/components/ui/Card.vue'
+
+interface Participant {
+  id: string
+  first_name: string
+  last_name: string
+  email: string
+  role: string
+}
+
+interface Project {
+  id: string
+  title: string
+  start_date: string
+  end_date: string
+  description: string
+  github_url?: string
+  project_url?: string
+  leader: Participant
+  participants: Participant[]
+}
 
 interface Props {
   projects: Project[]
@@ -9,21 +28,6 @@ interface Props {
 
 const props = defineProps<Props>()
 const { t } = useLanguage()
-
-// Methods
-const getStatusColor = (status: Project['status']) => {
-  const colors: Record<Project['status'], string> = {
-    active: 'bg-green-100 text-green-800',
-    completed: 'bg-blue-100 text-blue-800',
-    planned: 'bg-yellow-100 text-yellow-800'
-  }
-  return colors[status] || 'bg-gray-100 text-gray-800'
-}
-
-const getStatusLabel = (status: Project['status']) => {
-  const statusKey = status as keyof typeof t.value.research.featuredProjects.status
-  return t.value.research.featuredProjects.status[statusKey] || status
-}
 
 const openLink = (url: string) => {
   window.open(url, '_blank')
@@ -42,60 +46,62 @@ const openLink = (url: string) => {
         <div class="flex items-start justify-between mb-4">
           <div class="flex-1">
             <h3 class="text-lg font-semibold text-gray-900 mb-2">{{ project.title }}</h3>
-            <span :class="[
-              'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium',
-              getStatusColor(project.status)
-            ]">
-              {{ getStatusLabel(project.status) }}
-            </span>
           </div>
           <div class="text-right">
-            <p class="text-sm text-gray-500">{{ project.startDate }} - {{ project.endDate || t.research.featuredProjects.ongoing }}</p>
-            <p v-if="project.funding" class="text-sm font-medium text-[#08a4d4]">{{ project.funding }}</p>
+            <p class="text-sm text-gray-500">
+              {{ project.start_date }} - {{ project.end_date || t.research.featuredProjects.ongoing }}
+            </p>
           </div>
         </div>
 
         <p class="text-gray-700 mb-4 leading-relaxed">{{ project.description }}</p>
 
         <div class="mb-4">
-          <p class="text-sm font-medium text-gray-700 mb-2">{{ t.research.featuredProjects.leader }}:</p>
-          <p class="text-sm text-gray-600">{{ project.leadResearcher }}</p>
+          <p class="text-sm font-medium text-gray-700 mb-2">
+            {{ t.research.featuredProjects.leader }}:
+          </p>
+          <p class="text-sm text-gray-600">
+            {{ project.leader.first_name }} {{ project.leader.last_name }} ({{ project.leader.role }})
+          </p>
         </div>
 
         <div class="mb-4">
-          <p class="text-sm font-medium text-gray-700 mb-2">{{ t.research.featuredProjects.participants }}:</p>
+          <p class="text-sm font-medium text-gray-700 mb-2">
+            {{ t.research.featuredProjects.participants }}:
+          </p>
           <div class="flex flex-wrap gap-2">
-            <span v-for="participant in project.participants" :key="participant"
-              class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-              {{ participant }}
+            <span
+              v-for="participant in project.participants"
+              :key="participant.id"
+              class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800"
+            >
+              {{ participant.first_name }} {{ participant.last_name }}
             </span>
           </div>
         </div>
 
-        <div class="flex items-center justify-between">
-          <span
-            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-            {{ project.domain }}
-          </span>
-          <div class="flex space-x-2">
-            <a v-if="project.githubUrl" 
-               @click="openLink(project.githubUrl)"
-               class="text-gray-400 hover:text-[#08a4d4] transition-colors cursor-pointer">
-              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd"
-                  d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
-                  clip-rule="evenodd" />
-              </svg>
-            </a>
-            <a v-if="project.websiteUrl" 
-               @click="openLink(project.websiteUrl)"
-               class="text-gray-400 hover:text-[#08a4d4] transition-colors cursor-pointer">
-              <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-          </div>
+        <div class="flex items-center justify-end space-x-2">
+          <a
+            v-if="project.github_url"
+            @click="openLink(project.github_url)"
+            class="text-gray-400 hover:text-[#08a4d4] transition-colors cursor-pointer"
+          >
+            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd"
+                d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
+                clip-rule="evenodd" />
+            </svg>
+          </a>
+          <a
+            v-if="project.project_url"
+            @click="openLink(project.project_url)"
+            class="text-gray-400 hover:text-[#08a4d4] transition-colors cursor-pointer"
+          >
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
         </div>
       </Card>
     </div>

--- a/src/components/research/ResearchPage.vue
+++ b/src/components/research/ResearchPage.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useLanguage } from '@/composables/useLanguage'
-import { mockProjects, type Project } from '@/data/mockPublications'
-import { researchDomains } from '@/data/mockResearchers'
 
 // UI Components
 import PageHeader from '@/components/ui/PageHeader.vue'
@@ -11,83 +9,34 @@ import StatisticsGrid from '@/components/ui/StatisticsGrid.vue'
 // Research components
 import ResearchOverview from './ResearchOverview.vue'
 import FeaturedProjects from './FeaturedProjects.vue'
-import ResearchAreasAccordion from './ResearchAreasAccordion.vue'
 
 // Language and translations
 const { t } = useLanguage()
 
-// Computed
-const featuredProjects = computed(() => {
-  return mockProjects.filter(project => project.status === 'active').slice(0, 4)
+// State
+const researchProjects = ref([])
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+// Fetch API on component mount
+onMounted(async () => {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/researches`)
+    if (!res.ok) throw new Error('Failed to fetch research data')
+    researchProjects.value = await res.json()
+  } catch (error) {
+    console.error(error)
+  }
 })
 
-// Research areas with descriptions and icons
-const researchAreas = [
-  {
-    id: 'software-architecture',
-    name: 'Software Architecture',
-    description: t.value.research.domains.softwareArchitecture.description,
-    icon: '🏗️'
-  },
-  {
-    id: 'artificial-intelligence',
-    name: 'Machine Learning',
-    description: t.value.research.domains.artificialIntelligence.description,
-    icon: '🤖'
-  },
-  {
-    id: 'cybersecurity',
-    name: 'Cybersecurity',
-    description: t.value.research.domains.cybersecurity.description,
-    icon: '🔒'
-  },
-  {
-    id: 'devops',
-    name: 'DevOps',
-    description: t.value.research.domains.devops.description,
-    icon: '⚙️'
-  },
-  {
-    id: 'cloud-computing',
-    name: 'Cloud Computing',
-    description: t.value.research.domains.cloudComputing.description,
-    icon: '☁️'
-  },
-  {
-    id: 'software-testing',
-    name: 'Software Testing',
-    description: t.value.research.domains.softwareTesting.description,
-    icon: '🧪'
-  },
-  {
-    id: 'software-maintenance',
-    name: 'Software Maintenance',
-    description: t.value.research.domains.softwareMaintenance.description,
-    icon: '🔧'
-  },
-  {
-    id: 'human-computer-interaction',
-    name: 'Human-Computer Interaction',
-    description: t.value.research.domains.humanComputerInteraction.description,
-    icon: '👥'
-  }
-]
+// Featured Projects: just take first 4 for now
+const featuredProjects = computed(() => {
+  return researchProjects.value.slice(0, 4)
+})
 
-// Statistics
+// Statistics (dynamic length from API)
 const statistics = computed(() => [
-  { value: `${mockProjects.length}+`, label: t.value.research.overview.activeProjects },
-  { value: researchDomains.length, label: t.value.research.overview.researchDomains },
-  { value: '5+', label: t.value.research.overview.industryPartners }
+  { value: `${researchProjects.value.length}+`, label: t.value.research.overview.activeProjects }
 ])
-
-// Methods
-const getProjectsByDomain = (domain: string) => {
-  return mockProjects.filter(project =>
-    project.domain === domain ||
-    project.title.toLowerCase().includes(domain.toLowerCase()) ||
-    project.description.toLowerCase().includes(domain.toLowerCase())
-  )
-}
 </script>
 
 <template>
@@ -105,17 +54,11 @@ const getProjectsByDomain = (domain: string) => {
     <!-- Statistics -->
     <StatisticsGrid 
       :statistics="statistics"
-      :columns="3"
+      :columns="1"
       background-class="bg-gradient-to-r from-blue-50 to-indigo-50"
     />
 
     <!-- Featured Projects -->
     <FeaturedProjects :projects="featuredProjects" />
-
-    <!-- Research Areas Accordion -->
-    <ResearchAreasAccordion 
-      :research-areas="researchAreas"
-      :get-projects-by-domain="getProjectsByDomain"
-    />
   </div>
 </template>

--- a/src/test/research/ResearchPage.spec.ts
+++ b/src/test/research/ResearchPage.spec.ts
@@ -25,7 +25,7 @@ describe('ResearchPage.vue', () => {
 
     expect(statsGrid.exists()).toBe(true)
     expect(statsGrid.props('statistics')).toBeDefined()
-    expect(statsGrid.props('columns')).toBe(3)
+    expect(statsGrid.props('columns')).toBe(1)
     expect(statsGrid.props('backgroundClass')).toBe('bg-gradient-to-r from-blue-50 to-indigo-50')
   })
 
@@ -38,30 +38,5 @@ describe('ResearchPage.vue', () => {
     expect(Array.isArray(projectsProp)).toBe(true)
     expect(projectsProp.length).toBeLessThanOrEqual(4)
     expect(projectsProp.every(p => p.status === 'active')).toBe(true)
-  })
-
-  it('renders ResearchAreasAccordion with correct props', () => {
-    const wrapper = mount(ResearchPage)
-    const accordion = wrapper.findComponent({ name: 'ResearchAreasAccordion' })
-
-    expect(accordion.exists()).toBe(true)
-    expect(Array.isArray(accordion.props('researchAreas'))).toBe(true)
-    expect(typeof accordion.props('getProjectsByDomain')).toBe('function')
-  })
-
-  it('getProjectsByDomain returns projects matching domain or keyword', () => {
-    const wrapper = mount(ResearchPage)
-    const vm = wrapper.vm as any
-    const domain = 'software-development'
-
-    const results = vm.getProjectsByDomain(domain)
-    expect(Array.isArray(results)).toBe(true)
-    // Vérifier que chaque projet correspond au filtre
-    results.forEach((project: any) => {
-      const match = project.domain === domain ||
-                    project.title.toLowerCase().includes(domain.toLowerCase()) ||
-                    project.description.toLowerCase().includes(domain.toLowerCase())
-      expect(match).toBe(true)
-    })
   })
 })


### PR DESCRIPTION
## Description
Display researches on UI, according to the model.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (Please describe):

## Screenshots
<img width="621" height="702" alt="image" src="https://github.com/user-attachments/assets/2e725f0f-aa9e-420c-bb8c-480aba35861a" />

Since we do not have researches data, data has been created using the Django Admin Panel : 
<img width="1040" height="613" alt="image" src="https://github.com/user-attachments/assets/dafd592a-e91a-4238-bba7-a51946663d9e" />


## Additional Notes
Any additional notes or context regarding the changes can be added here.
