### PR TITLE
add a feature to send an email to  admins when a publication is added…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ DB_HOST=db
 DB_PORT=5432
 DB_NAME=postgres
 
+EMAIL_HOST=SMTP_SERVER_HOST
+EMAIL_PORT=SMTP_SERVER_PORT
+EMAIL_USE_TLS=False
+EMAIL_HOST_USER=email@example.com
+EMAIL_HOST_PASSWORD=CHANGE_ME
+BACKEND_URL="https://www.backend.example"
+
 VITE_API_BASE_URL=http://localhost:8000
 ```
 
@@ -59,6 +66,8 @@ pgAdmin login credentials:
 
 User: `admin@admin.com`  
 Password: `admin123`
+
+The mailhog server to test email delivery is available at `localhost:8025`.
 
 ## Additional Information
 

--- a/backend/backend/templates/emails/notify_admins.html
+++ b/backend/backend/templates/emails/notify_admins.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Publication Approval Needed</title>
+</head>
+
+<body>
+    <p>The following publications have been created or updated and require your approval:</p>
+
+    <ul>
+        {% for publication in publications_changed %}
+        <li>
+            <a href="{{ backend_url }}{{ publication.id }}/change/">
+                {{ publication.title }}
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+</body>
+
+</html>

--- a/backend/backend/templates/emails/notify_admins.txt
+++ b/backend/backend/templates/emails/notify_admins.txt
@@ -1,0 +1,5 @@
+The following publications have been created or updated and require your approval:
+
+ {% for publication in publications_changed %}
+- {{ publication.title }}: {{ backend_url }}{{ publication.id }}/change/
+{% endfor %}

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -156,3 +156,28 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.getenv("EMAIL_HOST", "localhost")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", 1025))
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "False").lower() == "true"
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "backend"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]

--- a/doc/programmerGuide/programmerGuide.md
+++ b/doc/programmerGuide/programmerGuide.md
@@ -102,6 +102,13 @@ DB_HOST=db
 DB_PORT=5432
 DB_NAME=postgres
 
+EMAIL_HOST=SMTP_SERVER_HOST
+EMAIL_PORT=SMTP_SERVER_PORT
+EMAIL_USE_TLS=False
+EMAIL_HOST_USER=email@example.com
+EMAIL_HOST_PASSWORD=CHANGE_ME
+BACKEND_URL="https://www.backend.example"
+
 VITE_API_BASE_URL=http://localhost:8000
 ```
 
@@ -122,6 +129,8 @@ pgAdmin login credentials:
 
 User: `admin@admin.com`  
 Password: `admin123`
+
+The mailhog server to test email delivery is available at `localhost:8025`.
 
 ### Frontend
 1. Install the required dependencies:
@@ -158,6 +167,7 @@ backend/
 │   ├─ models/
 │   ├─ serializers/
 │   ├─ services/
+│   ├─ templates/
 │   ├─ test/
 │   ├─ views/
 ├─ config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,12 @@ services:
         depends_on:
             - db
 
+    mailhog:
+        image: mailhog/mailhog
+        container_name: mailhog
+        ports:
+        - "1025:1025"  # SMTP port
+        - "8025:8025"  # Web UI port:
+
 volumes:
     postgres_data:


### PR DESCRIPTION
## Description
This PR adds a feature to send an email to all administrators when publications are created, updated or waiting approval.

To test it locally, the Docker compose file now includes a mailhog service to simulate email reception. The mailhog ui is available at `localhost:8025`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (Please describe):

## Screenshots
Mailhog UI
<img width="1915" height="195" alt="image" src="https://github.com/user-attachments/assets/7bd7e9d5-b6f7-4ae8-b137-82025570ec54" />

HTML email received in mailhog

<img width="1917" height="894" alt="image" src="https://github.com/user-attachments/assets/408d3de2-be80-4aed-8a72-00bcd80d9607" />

Text version of the email for browsers not supporting HTML emails

<img width="1893" height="907" alt="image" src="https://github.com/user-attachments/assets/9074df19-3c6f-496f-aacd-c6c6fbf78019" />

Clicking the link brings the user to the publication's Django admin page. They can review, update then approve the publication.

<img width="1897" height="910" alt="image" src="https://github.com/user-attachments/assets/3ec01d32-bba7-4fd7-87aa-2449896f23d7" />

After running the `getpublications` command a second time, we can see the previously approved publication was removed from the generated email.

<img width="1910" height="905" alt="image" src="https://github.com/user-attachments/assets/172f3cc5-56af-430c-8808-8573e870b18c" />


## Additional Notes
When deploying, we will absolutely need the following information:
```
EMAIL_HOST
EMAIL_PORT
EMAIL_USE_TLS
EMAIL_HOST_USER
EMAIL_HOST_PASSWORD
```
Further configuration might be needed on the SMTP server's side depending on what email is used. Example: https://www.codingforentrepreneurs.com/blog/sending-email-in-django-from-gmail