### PR TITLE
add a github action to run the getpublications command weekly

### DIFF
--- a/.github/workflows/cron-getpublications.yaml
+++ b/.github/workflows/cron-getpublications.yaml
@@ -1,0 +1,73 @@
+name: Weekly GetPublications Command Trigger
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Every Monday at midnight
+
+jobs:
+  run-command:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check required secrets
+        run: |
+          missing=false
+
+          if [ -z "${{ secrets.GITHUB_USERNAME }}" ]; then
+            echo "Missing secret: GITHUB_USERNAME"
+            missing=true
+          fi
+
+          if [ -z "${{ secrets.GITHUB_PASSWORD }}" ]; then
+            echo "Missing secret: GITHUB_PASSWORD"
+            missing=true
+          fi
+
+          if [ -z "${{ secrets.BACKEND_URL }}" ]; then
+            echo "Missing secret: BACKEND_URL"
+            missing=true
+          fi
+
+          if [ "$missing" = true ]; then
+            echo "One or more required secrets are missing. Failing the workflow."
+            exit 1
+          fi
+
+      - name: Run getpublications command
+        env:
+          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
+          GITHUB_PASSWORD: ${{ secrets.GITHUB_PASSWORD }}
+          BACKEND_URL: ${{ secrets.BACKEND_URL }}
+        run: |
+          echo "Logging in to $BACKEND_URL/api/login..."
+
+          LOGIN_RESPONSE=$(curl -s -X POST "$BACKEND_URL/api/login" \
+            -H "Content-Type: application/json" \
+            -d "{\"username_or_email\": \"$GITHUB_USERNAME\", \"password\": \"$GITHUB_PASSWORD\"}")
+
+          ACCESS_TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.access_token')
+
+          if [ "$ACCESS_TOKEN" = "null" ] || [ -z "$ACCESS_TOKEN" ]; then
+            echo "Login failed or access token missing"
+            echo "Response: $LOGIN_RESPONSE"
+            exit 1
+          fi
+
+          echo "Access token obtained. Sending command..."
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BACKEND_URL/run-getpublications-command" \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            -H "Content-Type: application/json")
+
+          HTTP_BODY=$(echo "$RESPONSE" | sed '$d')
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -n1) 
+
+          echo "Request response status: $HTTP_STATUS"
+          echo "Request response body:"
+          echo "$HTTP_BODY"
+
+          if [ "$HTTP_STATUS" -ne 202 ]; then
+            echo "Workflow failed"
+            exit 1
+          fi
+


### PR DESCRIPTION
## Description
This PR adds a Github workflow to run the `getpublications` command weekly. Three github secrets will be needed for this workflow to work:

GITHUB_USERNAME -> the name of the github user registered as a Django user (example: with the `createsuperuser` command)
GITHUB_PASSWORD -> the password for the github user.
BAKEND_URL

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (Please describe):

## Screenshots
Please provide screenshots of the changes, if possible.

## Additional Notes
We will only be able to truly test after deployment. In the meantime, we can test by:
1. Running the backend service with `docker compose up`.
2. Creating a user (through the admin panel or the `createsuperuser` command).
3. Running a custom script to simulate the workflow.

Test script:

cron-backend.sh
```bash

#!/bin/bash

# Fail on any error
set -e

GITHUB_USERNAME="github"
GITHUB_PASSWORD="github"
BACKEND_URL="http://host.docker.internal:8000"


echo "Logging in to $BACKEND_URL/api/login..."

LOGIN_RESPONSE=$(curl -s -X POST "$BACKEND_URL/api/login" \
  -H "Content-Type: application/json" \
  -d "{\"username_or_email\": \"$GITHUB_USERNAME\", \"password\": \"$GITHUB_PASSWORD\"}")

echo "Login response: $LOGIN_RESPONSE"

ACCESS_TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.access_token')

if [ "$ACCESS_TOKEN" = "null" ] || [ -z "$ACCESS_TOKEN" ]; then
  echo "Login failed or access token missing"
  exit 1
fi

echo "Access token obtained: $ACCESS_TOKEN"

RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BACKEND_URL/run-getpublications-command" \
  -H "Authorization: Bearer $ACCESS_TOKEN" \
  -H "Content-Type: application/json")

HTTP_BODY=$(echo "$RESPONSE" | sed '$d')            
HTTP_STATUS=$(echo "$RESPONSE" | tail -n1)           

echo "Request response status: $HTTP_STATUS"
echo "Request response body:"
echo "$HTTP_BODY"

if [ "$HTTP_STATUS" -ne 202 ]; then
  echo "Workflow failed"
  exit 1
fi

```
Dockerfile for the test script:

```Docker
FROM ubuntu:22.04

RUN apt-get update && \
    apt-get install -y curl jq bash && \
    apt-get clean

WORKDIR /app

COPY cron-backend.sh .
RUN chmod +x cron-backend.sh

CMD ["./cron-backend.sh"]
``` 

Then run 
```bash
docker build -t cron-test .
docker run --rm cron-test
```
