### PR TITLE
Added update and delete to research projects & added access token to auth response header

### DIFF
--- a/backend/backend/serializers/research_serializer.py
+++ b/backend/backend/serializers/research_serializer.py
@@ -71,3 +71,19 @@ class ResearchSerializer(serializers.ModelSerializer):
                 member = Member.objects.get(id=member_data["id"])
                 ProjectParticipant.objects.create(project=project, member=member)
         return project
+
+    def update(self, instance, validated_data):
+        members_data = validated_data.pop("participants", None)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        with transaction.atomic():
+            instance.save()
+
+            if members_data is not None:
+                ProjectParticipant.objects.filter(project=instance).delete()
+
+                for member_data in members_data:
+                    member = Member.objects.get(id=member_data["id"])
+                    ProjectParticipant.objects.create(project=instance, member=member)
+
+        return instance

--- a/backend/backend/views/auth_views.py
+++ b/backend/backend/views/auth_views.py
@@ -49,6 +49,8 @@ class LoginView(APIView):
                 "user": user,
             }
             response_serializer = LoginResponseSerializer(response_data)
-            return Response(response_serializer.data)
+            response = Response(response_serializer.data)
+            response.headers["Authorization"] = refresh.access_token
+            return response
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/backend/views/research_views.py
+++ b/backend/backend/views/research_views.py
@@ -40,3 +40,37 @@ class ResearchAPI(APIView):
             serializer.save(leader=member)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @swagger_auto_schema(
+        operation_id="Update Research",
+        operation_description="Update a research",
+        responses={200: ResearchSerializer},
+        tags=["Research"],
+    )
+    def put(self, request):
+        existing = ResearchProject.objects.filter(id=request.data.get("id"))
+
+        if not existing.exists():
+            return Response(
+                {"error": "The research you are trying to update does not exists"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        research = existing.first()
+        serializer = ResearchSerializer(instance=research, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @swagger_auto_schema(
+        operation_id="Delete research",
+        operation_description="Deletes a research",
+        responses={200: ResearchSerializer},
+        tags=["Research"],
+    )
+    def delete(self, request):
+        research = get_object_or_404(ResearchProject, id=request.data.get("id"))
+        research.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Description
Research projects can now be deleted and fullly or partially updated
Auth response should have the access_token in the headers

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (Please describe):
