### PR TITLE
Fixed member delete, fixed endpoint access & updated swagger doc

### DIFF
--- a/backend/backend/serializers/delete_serializer.py
+++ b/backend/backend/serializers/delete_serializer.py
@@ -1,5 +1,9 @@
 from rest_framework import serializers
 
 
-class DeleteSerializer(serializers.Serializer):
+class DeleteRequestSerializer(serializers.Serializer):
     id = serializers.UUIDField()
+
+
+class DeleteResponseSerializer(serializers.Serializer):
+    status = serializers.CharField()

--- a/backend/backend/views/awards_view.py
+++ b/backend/backend/views/awards_view.py
@@ -1,20 +1,23 @@
 from django.shortcuts import get_list_or_404, get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..models.award import Award
 from ..serializers.award_serializer import AwardSerializer
-from ..serializers.delete_serializer import DeleteSerializer
+from ..serializers.delete_serializer import (
+    DeleteRequestSerializer,
+    DeleteResponseSerializer,
+)
 
 
 class AwardsView(APIView):
     def get_permissions(self):
         if self.request.method == "GET":
             return [AllowAny()]
-        return [IsAuthenticated()]
+        return [IsAdminUser()]
 
     @swagger_auto_schema(
         operation_id="Get Awards",
@@ -28,8 +31,9 @@ class AwardsView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        operation_id="Create Awards",
+        operation_id="Create Awards (Admin)",
         operation_description="Creates a new award",
+        request_body=AwardSerializer,
         responses={201: AwardSerializer},
         tags=["Awards"],
     )
@@ -49,8 +53,9 @@ class AwardsView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Update Awards",
+        operation_id="Update Awards (Admin)",
         operation_description="Updates an award",
+        request_body=AwardSerializer,
         responses={200: AwardSerializer},
         tags=["Awards"],
     )
@@ -72,9 +77,10 @@ class AwardsView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Delete awards",
+        operation_id="Delete awards (Admin)",
         operation_description="Deletes an award",
-        responses={204: DeleteSerializer},
+        request_body=DeleteRequestSerializer,
+        responses={204: DeleteResponseSerializer},
         tags=["Awards"],
     )
     def delete(self, request):

--- a/backend/backend/views/courses_view.py
+++ b/backend/backend/views/courses_view.py
@@ -1,15 +1,24 @@
 from django.shortcuts import get_list_or_404, get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..models.course import Course
 from ..serializers.course_serializer import CourseSerializer
-from ..serializers.delete_serializer import DeleteSerializer
+from ..serializers.delete_serializer import (
+    DeleteRequestSerializer,
+    DeleteResponseSerializer,
+)
 
 
 class CoursesView(APIView):
+    def get_permissions(self):
+        if self.request.method == "GET":
+            return [AllowAny()]
+        return [IsAdminUser()]
+
     @swagger_auto_schema(
         operation_id="Get Courses",
         operation_description="Retrieves a list of all courses",
@@ -22,8 +31,9 @@ class CoursesView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        operation_id="Create Courses",
+        operation_id="Create Courses (Admin)",
         operation_description="Creates a new course",
+        request_body=CourseSerializer,
         responses={201: CourseSerializer},
         tags=["Courses"],
     )
@@ -43,8 +53,9 @@ class CoursesView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Update Courses",
+        operation_id="Update Courses (Admin)",
         operation_description="Updates a course",
+        request_body=CourseSerializer,
         responses={200: CourseSerializer},
         tags=["Courses"],
     )
@@ -66,9 +77,10 @@ class CoursesView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Delete courses",
+        operation_id="Delete courses (Admin)",
         operation_description="Deletes a course",
-        responses={204: DeleteSerializer},
+        request_body=DeleteRequestSerializer,
+        responses={204: DeleteResponseSerializer},
         tags=["Courses"],
     )
     def delete(self, request):

--- a/backend/backend/views/events_view.py
+++ b/backend/backend/views/events_view.py
@@ -1,21 +1,23 @@
 from django.shortcuts import get_list_or_404, get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..models.event import Event
-from ..serializers.delete_serializer import DeleteSerializer
+from ..serializers.delete_serializer import (
+    DeleteRequestSerializer,
+    DeleteResponseSerializer,
+)
 from ..serializers.event_serializer import EventSerializer
 
 
 class EventsView(APIView):
-
     def get_permissions(self):
         if self.request.method == "GET":
             return [AllowAny()]
-        return [IsAuthenticated()]
+        return [IsAdminUser()]
 
     @swagger_auto_schema(
         operation_id="Get Events",
@@ -29,8 +31,9 @@ class EventsView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        operation_id="Create Events",
+        operation_id="Create Events (Admin)",
         operation_description="Creates a new event",
+        request_body=EventSerializer,
         responses={201: EventSerializer},
         tags=["Events"],
     )
@@ -50,8 +53,9 @@ class EventsView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Update Events",
+        operation_id="Update Events (Admin)",
         operation_description="Updates an event",
+        request_body=EventSerializer,
         responses={200: EventSerializer},
         tags=["Events"],
     )
@@ -73,9 +77,10 @@ class EventsView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Delete events",
+        operation_id="Delete events (Admin)",
         operation_description="Deletes an event",
-        responses={204: DeleteSerializer},
+        request_body=DeleteRequestSerializer,
+        responses={204: DeleteResponseSerializer},
         tags=["Events"],
     )
     def delete(self, request):

--- a/backend/backend/views/profile_views.py
+++ b/backend/backend/views/profile_views.py
@@ -13,7 +13,7 @@ class ProfileView(APIView):
     permission_classes = [IsAuthenticated]
 
     @swagger_auto_schema(
-        operation_id="Get Profile",
+        operation_id="Get Profile (Member)",
         operation_description="Get the profile information of the authenticated user",
         responses={200: MemberSerializer},
         tags=["Profile"],
@@ -24,7 +24,7 @@ class ProfileView(APIView):
         return Response(serializer.data)
 
     @swagger_auto_schema(
-        operation_id="Partial Profile Update",
+        operation_id="Partial Profile Update (Member)",
         operation_description="Partial profile update of the authenticated user",
         request_body=ProfileUpdateSerializer,
         responses={200: MemberSerializer},
@@ -34,7 +34,7 @@ class ProfileView(APIView):
         return self.patch(request)
 
     @swagger_auto_schema(
-        operation_id="Partial Profile Update",
+        operation_id="Partial Profile Update (Member)",
         operation_description="Partial profile update of the authenticated user",
         request_body=ProfileUpdateSerializer,
         responses={200: MemberSerializer},

--- a/backend/backend/views/publication_views.py
+++ b/backend/backend/views/publication_views.py
@@ -1,21 +1,23 @@
 from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..models.publication import Publication
-from ..serializers.delete_serializer import DeleteSerializer
+from ..serializers.delete_serializer import (
+    DeleteRequestSerializer,
+    DeleteResponseSerializer,
+)
 from ..serializers.publication_serializer import PublicationSerializer
 
 
 class PublicationListAPI(APIView):
-
     def get_permissions(self):
         if self.request.method == "GET":
             return [AllowAny()]
-        return [IsAuthenticated()]
+        return [IsAdminUser()]
 
     @swagger_auto_schema(
         operation_id="Get Publications",
@@ -29,8 +31,9 @@ class PublicationListAPI(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        operation_id="Create Publication",
+        operation_id="Create Publication (Admin)",
         operation_description="Creates a new publication",
+        request_body=PublicationSerializer,
         responses={201: PublicationSerializer},
         tags=["Publication"],
     )
@@ -50,8 +53,9 @@ class PublicationListAPI(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Update Publication",
+        operation_id="Update Publication (Admin)",
         operation_description="Update a publication",
+        request_body=PublicationSerializer,
         responses={200: PublicationSerializer},
         tags=["Publication"],
     )
@@ -73,9 +77,10 @@ class PublicationListAPI(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Delete Publication",
+        operation_id="Delete Publication (Admin)",
         operation_description="Deletes a publication",
-        responses={204: DeleteSerializer},
+        request_body=DeleteRequestSerializer,
+        responses={204: DeleteResponseSerializer},
         tags=["Publication"],
     )
     def delete(self, request):

--- a/backend/backend/views/research_views.py
+++ b/backend/backend/views/research_views.py
@@ -1,13 +1,16 @@
 from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..models.member import Member
 from ..models.research_project import ResearchProject
-from ..serializers.delete_serializer import DeleteSerializer
+from ..serializers.delete_serializer import (
+    DeleteRequestSerializer,
+    DeleteResponseSerializer,
+)
 from ..serializers.research_serializer import ResearchSerializer
 
 
@@ -15,7 +18,7 @@ class ResearchAPI(APIView):
     def get_permissions(self):
         if self.request.method == "GET":
             return [AllowAny()]
-        return [IsAuthenticated()]
+        return [IsAdminUser()]
 
     @swagger_auto_schema(
         operation_id="Get Research Projects",
@@ -29,8 +32,9 @@ class ResearchAPI(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        operation_id="Create Research Projects",
+        operation_id="Create Research Projects (Admin)",
         operation_description="Creates a new research projects. Authentication required",
+        request_body=ResearchSerializer,
         responses={200: ResearchSerializer},
         tags=["Research"],
     )
@@ -43,8 +47,9 @@ class ResearchAPI(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Update Research",
+        operation_id="Update Research (Admin)",
         operation_description="Update a research",
+        request_body=ResearchSerializer,
         responses={200: ResearchSerializer},
         tags=["Research"],
     )
@@ -66,9 +71,10 @@ class ResearchAPI(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
-        operation_id="Delete research",
+        operation_id="Delete research (Admin)",
         operation_description="Deletes a research",
-        responses={204: DeleteSerializer},
+        request_body=DeleteRequestSerializer,
+        responses={204: DeleteResponseSerializer},
         tags=["Research"],
     )
     def delete(self, request):

--- a/backend/backend/views/run_getpublications_command_views.py
+++ b/backend/backend/views/run_getpublications_command_views.py
@@ -27,7 +27,7 @@ class RunGetPublicationsCommandAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     @swagger_auto_schema(
-        operation_id="Get Publication Command",
+        operation_id="Get Publication Command (Member)",
         operation_description="Runs the `getpublications` Admin command. Authentication required (Bearer Token)",
         responses={
             202: GetPublicationsCommandSerializer,

--- a/doc/usecase/usecase.puml
+++ b/doc/usecase/usecase.puml
@@ -31,7 +31,6 @@ Admin --> CU06
 Admin --> CU07
 
 ' Membre use cases
-Membre --> CU03
 Membre --> CU05
 Membre --> CU06
 Membre --> CU07


### PR DESCRIPTION
## Description
Things to check:
- When a member with no associated user is deleted, the member is fully deleted
- When a member is deleted with a user associated, the user is_active field is set to false. The member entry is not deleted
- The GET /api/members filters if an associated user is inactive and if there's no associated user, we still return this member
- Fixed the endpoint access (some endpoints are only accessible by an admin)
- Updated the swagger doc
  - Added (Admin) or (Member) to specify if the endpoints need an authenticated user or an authenticated admin
  - Added missing request body specifications
  - Changed the delete specifications of every endpoint (request & response) to be more accurate
- Fixed error in CU diagram
 

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (Please describe):

## Screenshots
<img width="1920" height="1897" alt="image" src="https://github.com/user-attachments/assets/9ebd6514-8255-4e79-ad87-76407ae7e655" />
<img width="1929" height="778" alt="image" src="https://github.com/user-attachments/assets/102c0d22-3bd5-4c77-b77e-fae76b443394" />
<img width="685" height="526" alt="image" src="https://github.com/user-attachments/assets/20f36769-6816-4205-be1e-d325b61368a3" />

