### PR TITLE
fix trailing / in publications endpoint

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/register", RegisterView.as_view(), name="register"),
     path("api/login", LoginView.as_view(), name="login"),
-    path("api/publications/", PublicationListAPI.as_view(), name="publication-list"),
+    path("api/publications", PublicationListAPI.as_view(), name="publication-list"),
     path("api/profile", ProfileView.as_view(), name="profile"),
     path("api/members", MemberListAPI.as_view(), name="member-list"),
     path("api/awards", AwardsView.as_view(), name="awards"),


### PR DESCRIPTION
## Description
Standardize the publication API to not include a trailing slash.
from `/api/publications/` to `/api/publications`  
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (Please describe):

## Screenshots
Please provide screenshots of the changes, if possible.

## Additional Notes
Any additional notes or context regarding the changes can be added here.
